### PR TITLE
include example script in npm distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   },
   "contributors": [],
   "files": [
-    "lib"
+    "lib",
+    "env.js",
+    "server.js"
   ],
   "main": "lib/charon.js",
   "dependencies": {


### PR DESCRIPTION
Make it so that people using npm install can use the example script.
They have to type `node ./path/to/styx/server.js` in order to use it.
