### PR TITLE
Ability to redirect http to https in styx

### DIFF
--- a/lib/rules/ruleBuilder.js
+++ b/lib/rules/ruleBuilder.js
@@ -24,6 +24,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+var util = require('util');
+
 var url = require('url');
 
 var _ = require('lodash');
@@ -112,6 +114,26 @@ module.exports = function(lifecycle, hakken, proxy) {
       lifecycle.add(service, watch);
       return proxyToWatch(watch);
     },
+    redirect: function(config) {
+      var host = pre.hasProperty(config, 'host');
+
+      return {
+        handle: function (req, res) {
+          var location = host + req.url;
+
+          res.writeHead(
+            301,
+            "Moved for goods, yo",
+            {
+              "Content-Type": "text/html",
+              "Location": location
+            }
+          );
+          res.end(util.format("<html><body><a href=\"%s\">%s/</a></body></html>", location, location));
+          return true;
+        }
+      }
+    },
     staticService: function(config) {
       var hosts = pre.isType(pre.hasProperty(config, 'hosts'), 'array');
       var name = 'unknown';
@@ -140,10 +162,14 @@ module.exports = function(lifecycle, hakken, proxy) {
 
       var retVal = {};
       for (var id in rules) {
-        retVal[id] = rules[id].map(function(spec) {
-          log.info('id[%s], building rule[%j]', id, spec);
-          return self.build(spec);
-        });
+        if (Array.isArray(rules[id])) {
+          retVal[id] = rules[id].map(function(spec) {
+            log.info('id[%s], building rule[%j]', id, spec);
+            return self.build(spec);
+          });
+        } else {
+          retVal[id] = self.buildAll(rules[id]);
+        }
       }
       return retVal;
     }

--- a/lib/styx.js
+++ b/lib/styx.js
@@ -26,8 +26,11 @@
 
 var util = require('util');
 
+var amoeba = require('amoeba');
+var except = amoeba.except;
+var pre = amoeba.pre;
+
 var charonFactory = require('./charon.js');
-var except = require('amoeba').except;
 var log = require('./log.js')('styx.js');
 
 module.exports = function () {
@@ -51,25 +54,45 @@ module.exports = function () {
         }
       }
 
-      var handler = makeHandlerFn(charonFactory(rules));
+      var httpHandler = null;
+      var httpsHandler = null;
+      if (rules.http != null || rules.https != null) {
+        if (rules.http != null) {
+          httpHandler = makeHandlerFn(charonFactory(rules.http))
+        }
+        if (rules.https != null) {
+          httpsHandler = makeHandlerFn(charonFactory(rules.https))
+        }
+      } else {
+        httpHandler = makeHandlerFn(charonFactory(rules));
+        httpsHandler = httpHandler;
+      }
 
       var objectsToManage = [];
       return {
         withHttp: function(port){
-          var server = require('http').createServer(handler);
+          pre.notNull(httpHandler, "Must specify http rules in order to listen on http");
+          var server = require('http').createServer(httpHandler);
           objectsToManage.push(
             {
-              start: function(){ server.listen(port); },
+              start: function(){
+                server.listen(port);
+                log.info('Styx HTTP on port[%s]', port);
+              },
               close: server.close.bind(server)
             }
           );
           return this;
         },
         withHttps: function(port, config){
-          var server = require('https').createServer(config, handler);
+          pre.notNull(httpsHandler, "Must specify https rules in order to listen on https");
+          var server = require('https').createServer(config, httpsHandler);
           objectsToManage.push(
             {
-              start: function(){ server.listen(port); },
+              start: function(){
+                server.listen(port);
+                log.info('Styx HTTPS on port[%s]', port);
+              },
               close: server.close.bind(server)
             }
           );
@@ -90,4 +113,4 @@ module.exports = function () {
       }
     }
   }
-}
+};


### PR DESCRIPTION
The ability is implemented in two things

1) Add the ability to configure http and https mappings separately
2) Add a blanket redirect rule that can be used to redirect traffic anywhere

@kentquirk @jh-bate give this a once over when you have a chance pls.  It's for

https://trello.com/c/i1tP05qa/135-notes-tidepool-io-needs-http-https-redirects
